### PR TITLE
Updated processing.py to check versions available on AlphaFoldDB

### DIFF
--- a/structuremap/processing.py
+++ b/structuremap/processing.py
@@ -101,7 +101,7 @@ def download_alphafold_pae(
     proteins: list,
     out_folder: str,
     out_format: str = "pae_{}.hdf",
-    alphafold_pae_url: str = 'https://alphafold.ebi.ac.uk/files/AF-{}-F1-predicted_aligned_error_v{version}.json',
+    alphafold_pae_url: str = 'https://alphafold.ebi.ac.uk/files/AF-{protein}-F1-predicted_aligned_error_v{version}.json',
     timeout: int = 60,
     verbose_log: bool = False,
 ) -> tuple:
@@ -153,7 +153,7 @@ def download_alphafold_pae(
         else:
             try:
                 for AFversion in AFversions:
-                    response = requests.get(alphafold_cif_url.format(protein=protein,version=AFversion))
+                    response = requests.get(alphafold_pae_url.format(protein=protein,version=AFversion))
                     if response.status_code == 200:
                         latest_AFversion = AFversion
                         break

--- a/structuremap/processing.py
+++ b/structuremap/processing.py
@@ -83,6 +83,8 @@ def download_alphafold_cif(
                 if response.status_code == 200:
                     latest_AFversion = AFversion
                     break
+                else:
+                    latest_AFversion = 404
             name_in = alphafold_cif_url.format(protein=protein,version=latest_AFversion)
             try:
                 urllib.request.urlretrieve(name_in, name_out)
@@ -157,6 +159,8 @@ def download_alphafold_pae(
                     if response.status_code == 200:
                         latest_AFversion = AFversion
                         break
+                    else:
+                        latest_AFversion = 404
                 name_in = alphafold_pae_url.format(protein=protein,version=latest_AFversion)
                 with tempfile.TemporaryDirectory() as tmp_pae_dir:
                     tmp_pae_file_name = os.path.join(

--- a/structuremap/processing.py
+++ b/structuremap/processing.py
@@ -71,12 +71,6 @@ def download_alphafold_cif(
     if not os.path.exists(out_folder):
         os.makedirs(out_folder)
     for protein in tqdm.tqdm(proteins):
-        for AFversion in AFversions:
-            response = requests.get(alphafold_cif_url.format(protein=protein,version=AFversion, type=bioType))
-            if response.status_code == 200:
-                latest_AFversion = AFversion
-                break
-        name_in = alphafold_cif_url.format(protein=protein,version=latest_AFversion)
         name_out = os.path.join(
             out_folder,
             out_format.format(protein)
@@ -84,6 +78,12 @@ def download_alphafold_cif(
         if os.path.isfile(name_out):
             existing_proteins.append(protein)
         else:
+            for AFversion in AFversions:
+                response = requests.get(alphafold_cif_url.format(protein=protein,version=AFversion))
+                if response.status_code == 200:
+                    latest_AFversion = AFversion
+                    break
+            name_in = alphafold_cif_url.format(protein=protein,version=latest_AFversion)
             try:
                 urllib.request.urlretrieve(name_in, name_out)
                 valid_proteins.append(protein)
@@ -101,7 +101,7 @@ def download_alphafold_pae(
     proteins: list,
     out_folder: str,
     out_format: str = "pae_{}.hdf",
-    alphafold_pae_url: str = 'https://alphafold.ebi.ac.uk/files/AF-{}-F1-predicted_aligned_error_v1.json',
+    alphafold_pae_url: str = 'https://alphafold.ebi.ac.uk/files/AF-{}-F1-predicted_aligned_error_v{version}.json',
     timeout: int = 60,
     verbose_log: bool = False,
 ) -> tuple:
@@ -140,6 +140,7 @@ def download_alphafold_pae(
     valid_proteins = []
     invalid_proteins = []
     existing_proteins = []
+    AFversions = [9, 8, 7, 6, 5, 4, 3, 2, 1] #Dirty fix, but should hold up for the foreseeable future
     if not os.path.exists(out_folder):
         os.makedirs(out_folder)
     for protein in tqdm.tqdm(proteins):
@@ -151,7 +152,12 @@ def download_alphafold_pae(
             existing_proteins.append(protein)
         else:
             try:
-                name_in = alphafold_pae_url.format(protein)
+                for AFversion in AFversions:
+                    response = requests.get(alphafold_cif_url.format(protein=protein,version=AFversion))
+                    if response.status_code == 200:
+                        latest_AFversion = AFversion
+                        break
+                name_in = alphafold_pae_url.format(protein=protein,version=latest_AFversion)
                 with tempfile.TemporaryDirectory() as tmp_pae_dir:
                     tmp_pae_file_name = os.path.join(
                         tmp_pae_dir,

--- a/structuremap/processing.py
+++ b/structuremap/processing.py
@@ -166,7 +166,10 @@ def download_alphafold_pae(
                     urllib.request.urlretrieve(name_in, tmp_pae_file_name)
                     with open(tmp_pae_file_name) as tmp_pae_file:
                         data = json.loads(tmp_pae_file.read())
-                dist = np.array(data[0]['distance'])
+                if latest_AFversion < 3: 
+                    dist = np.array(data[0]['distance'])
+                else:
+                    dist = [item for sublist in data[0]["predicted_aligned_error"] for item in sublist]
                 data_list = [('dist', dist)]
                 if getattr(sys, 'frozen', False):
                     print('Using frozen h5py w/ gzip compression')


### PR DESCRIPTION
Added a simple loop that per protein searches for the latest release (usually v4) and uses that information. Also incorporates an altered parsing of the changed JSON schema of the PAE of v3 and v4 models.
Benefit of these changes is that the module now works for all species in the AlphaFold DB, many of which lack a v1 version. 