### PR TITLE
Bump version: 0.0.9 → 0.0.10

### DIFF
--- a/misc/bumpversion.cfg
+++ b/misc/bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.9
+current_version = 0.0.10
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/release/one_click_linux_gui/control
+++ b/release/one_click_linux_gui/control
@@ -1,5 +1,5 @@
 Package: structuremap
-Version: 0.0.9
+Version: 0.0.10
 Architecture: all
 Maintainer: Mann Labs <opensource@alphapept.com>
 Description: structuremap

--- a/release/one_click_linux_gui/create_installer_linux.sh
+++ b/release/one_click_linux_gui/create_installer_linux.sh
@@ -17,7 +17,7 @@ python setup.py sdist bdist_wheel
 # Setting up the local package
 cd release/one_click_linux_gui
 # Make sure you include the required extra packages and always use the stable or very-stable options!
-pip install "../../dist/structuremap-0.0.9-py3-none-any.whl[stable]"
+pip install "../../dist/structuremap-0.0.10-py3-none-any.whl[stable]"
 
 # Creating the stand-alone pyinstaller folder
 pip install pyinstaller==4.2

--- a/release/one_click_macos_gui/Info.plist
+++ b/release/one_click_macos_gui/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIconFile</key>
 	<string>alpha_logo.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>structuremap.0.0.9</string>
+	<string>structuremap.0.0.10</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.9</string>
+	<string>0.0.10</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/release/one_click_macos_gui/create_installer_macos.sh
+++ b/release/one_click_macos_gui/create_installer_macos.sh
@@ -20,7 +20,7 @@ python setup.py sdist bdist_wheel
 
 # Setting up the local package
 cd release/one_click_macos_gui
-pip install "../../dist/structuremap-0.0.9-py3-none-any.whl[stable]"
+pip install "../../dist/structuremap-0.0.10-py3-none-any.whl[stable]"
 
 # Creating the stand-alone pyinstaller folder
 pip install pyinstaller==4.2
@@ -40,5 +40,5 @@ cp ../../LICENSE.txt Resources/LICENSE.txt
 cp ../logos/alpha_logo.png Resources/alpha_logo.png
 chmod 777 scripts/*
 
-pkgbuild --root dist/structuremap --identifier de.mpg.biochem.structuremap.app --version 0.0.9 --install-location /Applications/structuremap.app --scripts scripts structuremap.pkg
+pkgbuild --root dist/structuremap --identifier de.mpg.biochem.structuremap.app --version 0.0.10 --install-location /Applications/structuremap.app --scripts scripts structuremap.pkg
 productbuild --distribution distribution.xml --resources Resources --package-path structuremap.pkg dist/structuremap_gui_installer_macos.pkg

--- a/release/one_click_macos_gui/distribution.xml
+++ b/release/one_click_macos_gui/distribution.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <installer-script minSpecVersion="1.000000">
-    <title>structuremap 0.0.9</title>
+    <title>structuremap 0.0.10</title>
     <background mime-type="image/png" file="alpha_logo.png" scaling="proportional"/>
     <welcome file="welcome.html" mime-type="text/html" />
     <conclusion file="conclusion.html" mime-type="text/html" />

--- a/release/one_click_windows_gui/create_installer_windows.sh
+++ b/release/one_click_windows_gui/create_installer_windows.sh
@@ -17,7 +17,7 @@ python setup.py sdist bdist_wheel
 # Setting up the local package
 cd release/one_click_windows_gui
 # Make sure you include the required extra packages and always use the stable or very-stable options!
-pip install "../../dist/structuremap-0.0.9-py3-none-any.whl[stable]"
+pip install "../../dist/structuremap-0.0.10-py3-none-any.whl[stable]"
 
 # Creating the stand-alone pyinstaller folder
 pip install pyinstaller==4.2

--- a/release/one_click_windows_gui/structuremap_innoinstaller.iss
+++ b/release/one_click_windows_gui/structuremap_innoinstaller.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "structuremap"
-#define MyAppVersion "0.0.9"
+#define MyAppVersion "0.0.10"
 #define MyAppPublisher "Max Planck Institute of Biochemistry and the University of Copenhagen, Mann Labs"
 #define MyAppURL "https://github.com/MannLabs/structuremap"
 #define MyAppExeName "structuremap_gui.exe"

--- a/structuremap/__init__.py
+++ b/structuremap/__init__.py
@@ -2,7 +2,7 @@
 
 
 __project__ = "structuremap"
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 __license__ = "Apache"
 __description__ = "An open-source Python package of the AlphaPept ecosystem"
 __author__ = "Isabell Bludau & Mann Labs"


### PR DESCRIPTION
Request version bump to 0.0.10 for PyPI release.

The master branch has removed the Python<3.10 requirement, but this change isn't reflected in the latest PyPI release (0.0.9). 

This PR bumps the version to 0.0.10 (no other changes). Once this PR is merged, could you create a new PyPI release to make the package compatible with Python 3.10+.